### PR TITLE
feat: start_assign flag for ASSIGN web endpoint startup

### DIFF
--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: assign-test-master:latest
+    image: assign:1.0.0
     environment:
       assign_sha: ""
     ports:

--- a/containers/assign/Dockerfile
+++ b/containers/assign/Dockerfile
@@ -17,6 +17,7 @@ ENV assign_sha=""
 ENV abp_dir="/data/ABP"
 ENV abp_checksum="/data/abp_checksum"
 ENV ydb_checksum="/data/ydb_checksum"
+ENV start_assign="false"
 
 # YDB env vars
 ARG YDB_VERSION

--- a/containers/assign/Dockerfile
+++ b/containers/assign/Dockerfile
@@ -17,7 +17,7 @@ ENV assign_sha=""
 ENV abp_dir="/data/ABP"
 ENV abp_checksum="/data/abp_checksum"
 ENV ydb_checksum="/data/ydb_checksum"
-ENV start_assign="false"
+ENV start_assign="true"
 
 # YDB env vars
 ARG YDB_VERSION

--- a/startup_scripts/assign-startup.sh
+++ b/startup_scripts/assign-startup.sh
@@ -68,7 +68,7 @@ function calc_abp_checksum { sha256sum $abp_dir/* | sha256sum | awk '{ print $1 
 function calc_ydb_checksum { sha256sum $ydb_gbldir | awk '{ print $1 }'; }
 
 function load_abp_to_assign {
-  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")'
+  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")' && \
   echo "Ingest okay. Producing checksum for $ydb_gbldir." && calc_ydb_checksum > $ydb_checksum && \
   echo "Producing checksum for $abp_dir." && calc_abp_checksum > $abp_checksum
   }


### PR DESCRIPTION
## :construction: Suggest a change

Set an env var `start_assign` to determine whether to start up the web services after ABP is loaded. Not necessarily needed due to how the init container is working, but useful to have. 

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
