### PR TITLE
feat: ABP load logic based on env var and single flag file

### DIFF
--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: assign-test-master:latest
+    image: assign:1.0.0
     environment:
       assign_sha: ""
     ports:

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -3,6 +3,8 @@ services:
     image: assign:1.0.0
     environment:
       assign_sha: ""
+      start_assign: "false"
+      trigger_abp_load: "false"
     ports:
       - "9080:9080"
       - "9081:9081"

--- a/containers/assign/Dockerfile
+++ b/containers/assign/Dockerfile
@@ -17,6 +17,7 @@ ENV assign_sha=""
 ENV abp_dir="/data/ABP"
 ENV abp_checksum="/data/abp_checksum"
 ENV ydb_checksum="/data/ydb_checksum"
+ENV start_assign="true"
 
 # YDB env vars
 ARG YDB_VERSION

--- a/containers/assign/Dockerfile
+++ b/containers/assign/Dockerfile
@@ -15,8 +15,8 @@ ENV assign_url="https://github.com/endeavourhealth-discovery/ASSIGN.git"
 ENV assign_dest="/data/ASSIGN"
 ENV assign_sha=""
 ENV abp_dir="/data/ABP"
-ENV abp_checksum="/data/abp_checksum"
-ENV ydb_checksum="/data/ydb_checksum"
+ENV abp_checkfile="$abp_dir/abp_checkfile"
+ENV trigger_abp_load="false"
 ENV start_assign="true"
 
 # YDB env vars

--- a/startup_scripts/assign-startup.sh
+++ b/startup_scripts/assign-startup.sh
@@ -91,20 +91,29 @@ else
   echo "Checksums match, no need to reload."
 fi
 
-# Set the ybd env var for the TLS password hash, this can be replaced with an ENV var in the image?
-#export ydb_tls_passwd_dev="$($ydb_dist/plugin/ydbcrypt/maskpass <<< $cert_pass | cut -d ":" -f2 | tr -d ' ')"
 
-# Startup the ASSIGN TLS listener
-echo "Starting listener"
-yottadb -run %XCMD 'job START^VPRJREQ(9081)' &
+if [[ ! -f "$abp_checksum" || ! -f "$ydb_checksum" ]]; then
+  echo "Checksums are missing. Not starting ASSIGN web endpoint."
+else
+  if [ "$start_assign" == "true" ]; then
+    # Set the ybd env var for the TLS password hash, this can be replaced with an ENV var in the image?
+    #export ydb_tls_passwd_dev="$($ydb_dist/plugin/ydbcrypt/maskpass <<< $cert_pass | cut -d ":" -f2 | tr -d ' ')"
 
-# Startup the ASSIGN web API interface
-echo "Starting ASSIGN API endpoints"
-cp "/extra_scripts/ADDWEBAUTH.m" "$ydb_dir/$ydb_rel/r/ADDWEBAUTH.m"
-yottadb -run INT^VUE          # File upload/download
-yottadb -run SETUP^UPRNHOOK2  # UPRN retrieval
-yottadb -run ^NEL             # request handling
-yottadb -run ^ADDWEBAUTH      # Add creds
+    # Startup the ASSIGN web endpoint
+    echo "Starting listener"
+    yottadb -run %XCMD 'job START^VPRJREQ(9081)' &
+
+    # Startup the ASSIGN web API interface
+    echo "Starting ASSIGN API endpoints"
+    cp "/extra_scripts/ADDWEBAUTH.m" "$ydb_dir/$ydb_rel/r/ADDWEBAUTH.m"
+    yottadb -run INT^VUE          # File upload/download
+    yottadb -run SETUP^UPRNHOOK2  # UPRN retrieval
+    yottadb -run ^NEL             # request handling
+    yottadb -run ^ADDWEBAUTH      # Add creds
+  else
+    echo "Not starting ASSIGN web endpoint due to start_assign flag."
+  fi
+fi
 } &
 
 # Startup webgui.

--- a/startup_scripts/assign-startup.sh
+++ b/startup_scripts/assign-startup.sh
@@ -17,28 +17,43 @@ else
   echo "ydb_dist already set. Not setting variables again."
 fi
 
-# Check if ASSIGN needs pulling
+# Check if we need to explicitly state sha from empty sha request
 if [ "$assign_sha" == "" ]; then
   echo "Given sha was empty, using HEAD of $assign_url."
   assign_sha=$(git ls-remote $assign_url HEAD | cut -f1 | cut -c1-7)
   echo "New value for assign_sha is $assign_sha. Matching remote HEAD sha."
 fi
 
-if [[ -d "$assign_dest" && "$assign_sha" == $(git -C $assign_dest rev-parse --short HEAD) ]]; then
+# Check if ASSIGN needs pulling
+if [[ -d "$assign_dest" && "${assign_sha::7}" == $(git -C $assign_dest rev-parse --short HEAD) ]]; then
   # Exists and matches
   echo "Previous ASSIGN installation found matching current sha. No need to change ASSIGN."
 else
   # Check if exists, get it if not
   if [ ! -d "$assign_dest" ]; then
     echo "ASSIGN not previously installed. Obtaining ASSIGN routines." && git clone $assign_url $assign_dest
+    # Set flag to trigger ABP reload
+    echo "Import mumps code has changed, setting flag to trigger reload."
+    trigger_abp_load="true"
   else
+    # Get current sha
+    cur_sha=$(git -C $assign_dest rev-parse --short HEAD)
+
     # Check if wanted sha exists in current clone
-    echo "Current version of sha does not match that requested. Will re-install ASSIGN."
+    echo "Current sha does not match that requested. Will re-install ASSIGN."
     echo "Checking if wanted sha exists in current clone of repo."
     if ! git -C $assign_dest cat-file -e $assign_sha^{commit}; then
       echo "sha not found, pulling remote." && git -C $assign_dest reset --hard origin/master && git -C $assign_dest clean -fxd && git -C $assign_dest pull
     else
       echo "sha $assign_sha found, no need to pull."
+    fi
+
+    # Set flag to trigger ABP reload
+    if ! git -C $assign_dest diff --quiet $cur_sha $assign_sha -- $assign_dest/UPRN/yottadb/UPRN1A.m || ! git -C $assign_dest diff --quiet $cur_sha $assign_sha -- $assign_dest/UPRN/yottadb/UPRNIND.m ; then
+      echo "Import mumps code has changed, setting flag to trigger reload."
+      trigger_abp_load="true"
+    else
+      echo "Import mumps code has not changed."
     fi
   fi
 
@@ -63,37 +78,49 @@ $ydb_dist/mupip set -extension_count=500000 -region DEFAULT && \
 $ydb_dist/mupip set -journal=off -region DEFAULT #&& \
 #$ydb_dist/mupip set -access_method=mm -region DEFAULT
 
-# Check if data needs loading
-function calc_abp_checksum { sha256sum $abp_dir/* | sha256sum | awk '{ print $1 }'; }
-function calc_ydb_checksum { sha256sum $ydb_gbldir | awk '{ print $1 }'; }
-
-function load_abp_to_assign {
-  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")' && \
-  echo "Ingest okay. Producing checksum for $ydb_gbldir." && calc_ydb_checksum > $ydb_checksum && \
-  echo "Producing checksum for $abp_dir." && calc_abp_checksum > $abp_checksum
+# Produce checksum for ABP data
+function calc_abp_checksum {
+  sha256sum $abp_dir/* | sha256sum | awk '{ print $1 }'
   }
 
+# Removing check file
+function clear_checkfile {
+  echo "Removing old check files."
+  [ -e $abp_checkfile ] && rm $abp_checkfile
+  }
+
+function create_checkfile {
+  echo "Producing checkfile for ABP load."
+  echo "ABP loaded on $(date +%Y_%m_%d)" > $abp_checkfile
+}
+
+# Loading ABP
+function load_abp_to_assign {
+  # Reload
+  clear_checkfile
+  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")'
+  echo "Ingest okay." && create_checkfile
+  }
+
+# Subprocess to load ABP data
 {
-# If either ABP checksum or YDB checksum are missing then we presume data hasn't been loaded previously.
-if [[ ! -f "$abp_checksum" || ! -f "$ydb_checksum" ]]; then
-  if [ ! -f "$abp_checksum" ]; then echo "$abp_checksum is missing."; fi
-  if [ ! -f "$ydb_checksum" ]; then echo "$ydb_checksum is missing."; fi
-  echo "A checksum for the data is missing. Reloading data."
-  load_abp_to_assign
-# else if the checksums don't match...
-elif [[ $(cat $abp_checksum) != $(calc_abp_checksum) || $(cat $ydb_checksum) != $(calc_ydb_checksum) ]]; then
-  echo "Prev ABP checksum: $(cat $abp_checksum)\nCurr ABP checksum: $(calc_abp_checksum)"
-  echo "Prev YDB checksum: $(cat $ydb_checksum)\nCurr YDB checksum: $(calc_ydb_checksum)"
-  echo "A checksum does not match. Reloading data."
-  load_abp_to_assign
-# else they match
-else
-  echo "Checksums match, no need to reload."
+# If needed, remove previous check to trigger the load
+if [ "$trigger_abp_load" == "true" ]; then
+  echo "trigger_abp_load set to true, triggering a load."
+  clear_checkfile
 fi
 
+# If ABP checksum is missing then we presume data needs loading.
+if [[ ! -f "$abp_checkfile" ]]; then
+  echo "$abp_checkfile is missing. Loading data."
+  load_abp_to_assign
+else
+  echo "Checkfile exists, no need to load."
+fi
 
-if [[ ! -f "$abp_checksum" || ! -f "$ydb_checksum" ]]; then
-  echo "Checksums are missing. Not starting ASSIGN web endpoint."
+# See if we want to start up ASSIGN web endpoint
+if [[ ! -f "$abp_checkfile" ]]; then
+  echo "Checksum is missing. Not starting ASSIGN web endpoint."
 else
   if [ "$start_assign" == "true" ]; then
     # Set the ybd env var for the TLS password hash, this can be replaced with an ENV var in the image?

--- a/startup_scripts/assign-startup.sh
+++ b/startup_scripts/assign-startup.sh
@@ -98,7 +98,7 @@ function create_checkfile {
 function load_abp_to_assign {
   # Reload
   clear_checkfile
-  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")'
+  echo "Importing ABP from $abp_dir." && $ydb_dist/ydb -run %XCMD 'd IMPORT^UPRN1A("/data/ABP")' && \
   echo "Ingest okay." && create_checkfile
   }
 


### PR DESCRIPTION
## :construction: Suggest a change

ABP and YDB checkfiles to be merged, making reload logic more concise, adding env var flagging the need to (re)load ABP.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :poop: Have commits been checked for accidental file inclusions?
